### PR TITLE
build: Add GitHub Actions badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Christopher Gandrud CV
 ===
 
+[![Build CV PDF document](https://github.com/christophergandrud/cv/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/christophergandrud/cv/actions/workflows/main.yml)
+
 My CV. 
 
 &copy; Christopher Gandrud (2024)


### PR DESCRIPTION
Add GitHub Actions badge to display build status of CV PDF document.